### PR TITLE
Navigation slots

### DIFF
--- a/views/nav-list.blade.php
+++ b/views/nav-list.blade.php
@@ -12,7 +12,7 @@
         'items' => $list,
         'active_class' => $active_class,
         ])
-    {{ $slot }}
+    {!! $slot !!}
    </ul>
 </nav>
 


### PR DESCRIPTION
Added a default slot to extend the navigation list with another component or list entry. 
Though more slots - outside the `ul`, to prepend or append the list could be useful too.

Also tried to tidy up a little bit and improve the if statements when selecting the navigation styles.