### PR TITLE
set correct translatin locale in litstack

### DIFF
--- a/src/Localize/TransRoute.php
+++ b/src/Localize/TransRoute.php
@@ -32,6 +32,10 @@ class TransRoute
      */
     public function getLocale()
     {
+        if (explode('/', request()->path())[0] === config('lit.route_prefix')) {
+            return $this->getFallbackLocale();
+        }
+        
         if (count($this->locales) <= 1) {
             return $this->getFallbackLocale();
         }


### PR DESCRIPTION
With this PR bladesmith sets the correct default language for translated forms in litstack.