### PR TITLE
Fix getMediaConversions for laravel-medialibrary v9

### DIFF
--- a/src/Components/ImageComponent.php
+++ b/src/Components/ImageComponent.php
@@ -104,7 +104,12 @@ class ImageComponent extends Component
      */
     protected function getMediaConversions()
     {
-        return collect($this->getCustomProperty('generated_conversions', false))
+        $conversions = $this->getCustomProperty('generated_conversions', false);
+        if (is_null($conversions)) {
+            $conversions = $this->image->generated_conversions;
+        }
+
+        return collect($conversions)
             ->filter(fn ($value) => $value == true)
             ->keys()
             ->mapWithKeys(function ($conversion) {


### PR DESCRIPTION
Da die Image conversions seit v9 nicht mehr in der spalte `custom_properties` landen, sondern einer eigenen Datenbank spalte, werden keine conversions mehr gefunden und die Image Komponente spuckt das (große) Original aus, ohne thumbnail, lazy loading, etc.


