### PR TITLE
fix for issue #12

### DIFF
--- a/src/Macros/CrudNavMacro.php
+++ b/src/Macros/CrudNavMacro.php
@@ -23,7 +23,7 @@ class CrudNavMacro
                 $form->boolean('external')->title('External Link');
 
                 // Route field.
-                $form->route('route')->title('Route (intern)')->collection('app')->allowEmpty()->when('external', false)->orWhen('external', null);
+                $form->route('route')->title('Route (intern)')->collection('app')->allowEmpty()->whenNot('external', true);
 
                 // URL field.
                 $form->input('url')->title('URL (extern)')->when('external', true);


### PR DESCRIPTION
Solves: With a new nav element the input mask starts without the route select and also without the url input. you have to set the boolean on and off to get the route select displayed.