### PR TITLE
Fix translatable input always translated

### DIFF
--- a/src/Macros/CrudNavMacro.php
+++ b/src/Macros/CrudNavMacro.php
@@ -17,7 +17,7 @@ class CrudNavMacro
         CrudShow::macro('nav', function ($name, Closure $closure = null) {
             return $this->list($name)->previewTitle('{title}')->form(function ($form) use ($closure) {
                 // Title field.
-                $form->input('title')->title('Link Text')->translatable()->width(8);
+                $form->input('title')->title('Link Text')->translatable(lit()->isAppTranslatable())->width(8);
                 
                 // External.
                 $form->boolean('external')->title('External Link');


### PR DESCRIPTION
Currently nav title input field currently is always translated, even though the app might not be.

This PR changes the input translatability to take the app translatability into consideration.