### PR TITLE
add abort to 404 when current page doesn't exist

### DIFF
--- a/src/Localize/LocalizeServiceProvider.php
+++ b/src/Localize/LocalizeServiceProvider.php
@@ -99,7 +99,10 @@ class LocalizeServiceProvider extends ServiceProvider
             if (lit()->isAppTranslatable()) {
                 $routes->extend(function (Route $route) {
                     $route->translator(function ($locale, $slug = null) {
-                        $slug = Page::current()->translate($locale)->t_slug;
+                        $slug = Page::current()?->translate($locale)->t_slug;
+                        if (! $slug) {
+                            abort(404);
+                        }
 
                         return ['slug' => $slug];
                     });


### PR DESCRIPTION
When trying to use `request()->route()->translate($locale);` on a route that doesn't exist the resolver will throw an error saying that `translate()` can't be called on null. Since the correct behavior should be to abort and show a 404 error page I added acheck for weither the slug exists and if not it should call `abort(404)`